### PR TITLE
Update docker-stack.yml - add depends_on

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -29,6 +29,8 @@ services:
       - portainer_data:/data
     networks:
       - agent_network
+    depends_on:
+      - agent
     deploy:
       mode: replicated
       replicas: 1


### PR DESCRIPTION
Setting up portainer on a fresh server, I visited the portainer UI and noticed there was a failed `portainer` task as it couldn't connect to tcp 9001. I assume because the agent was starting up and not yet healthy. 

This change addresses that (but I have not been able to verify it). 